### PR TITLE
chore: Bump multer past CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "dependencies": {
         "@arcjet/decorate": "1.0.0-beta.9",
         "@arcjet/nest": "1.0.0-beta.9",
-        "@nestjs/common": "11.1.3",
+        "@nestjs/common": "11.1.5",
         "@nestjs/config": "4.0.2",
-        "@nestjs/core": "11.1.3",
-        "@nestjs/platform-express": "11.1.3",
+        "@nestjs/core": "11.1.5",
+        "@nestjs/platform-express": "11.1.5",
         "class-transformer": "0.5.1",
         "class-validator": "0.14.2",
         "reflect-metadata": "0.2.2",
@@ -938,9 +938,9 @@
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "11.1.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.3.tgz",
-      "integrity": "sha512-ogEK+GriWodIwCw6buQ1rpcH4Kx+G7YQ9EwuPySI3rS05pSdtQ++UhucjusSI9apNidv+QURBztJkRecwwJQXg==",
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.5.tgz",
+      "integrity": "sha512-DQpWdr3ShO0BHWkHl3I4W/jR6R3pDtxyBlmrpTuZF+PXxQyBXNvsUne0Wyo6QHPEDi+pAz9XchBFoKbqOhcdTg==",
       "license": "MIT",
       "dependencies": {
         "file-type": "21.0.0",
@@ -984,9 +984,9 @@
       }
     },
     "node_modules/@nestjs/core": {
-      "version": "11.1.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.3.tgz",
-      "integrity": "sha512-5lTni0TCh8x7bXETRD57pQFnKnEg1T6M+VLE7wAmyQRIecKQU+2inRGZD+A4v2DC1I04eA0WffP0GKLxjOKlzw==",
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.5.tgz",
+      "integrity": "sha512-Qr25MEY9t8VsMETy7eXQ0cNXqu0lzuFrrTr+f+1G57ABCtV5Pogm7n9bF71OU2bnkDD32Bi4hQLeFR90cku3Tw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1025,14 +1025,14 @@
       }
     },
     "node_modules/@nestjs/platform-express": {
-      "version": "11.1.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.3.tgz",
-      "integrity": "sha512-hEDNMlaPiBO72fxxX/CuRQL3MEhKRc/sIYGVoXjrnw6hTxZdezvvM6A95UaLsYknfmcZZa/CdG1SMBZOu9agHQ==",
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.5.tgz",
+      "integrity": "sha512-OsoiUBY9Shs5IG3uvDIt9/IDfY5OlvWBESuB/K4Eun8xILw1EK5d5qMfC3d2sIJ+kA3l+kBR1d/RuzH7VprLIg==",
       "license": "MIT",
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.1.0",
-        "multer": "2.0.1",
+        "multer": "2.0.2",
         "path-to-regexp": "8.2.0",
         "tslib": "2.8.1"
       },
@@ -3337,9 +3337,9 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.1.tgz",
-      "integrity": "sha512-Ug8bXeTIUlxurg8xLTEskKShvcKDZALo1THEX5E41pYCD2sCVub5/kIRIGqWNoqV6szyLyQKV6mD4QUrWE5GCQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
+      "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
   "dependencies": {
     "@arcjet/decorate": "1.0.0-beta.9",
     "@arcjet/nest": "1.0.0-beta.9",
-    "@nestjs/common": "11.1.3",
+    "@nestjs/common": "11.1.5",
     "@nestjs/config": "4.0.2",
-    "@nestjs/core": "11.1.3",
-    "@nestjs/platform-express": "11.1.3",
+    "@nestjs/core": "11.1.5",
+    "@nestjs/platform-express": "11.1.5",
     "class-transformer": "0.5.1",
     "class-validator": "0.14.2",
     "reflect-metadata": "0.2.2",


### PR DESCRIPTION
Bump multer out of range based on this advisory: https://github.com/arcjet/example-nestjs/security/dependabot/14