### PR TITLE
chore: Initial publish from monorepo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
       # Arcjet packages are grouped alone due to not being major/minor/patch yet
       arcjet-js:
         patterns:
-          - 'arcjet'
+          - arcjet
           - '@arcjet/*'
     ignore:
       # Synced with engines field in package.json

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD033 MD041 -->
 <a href="https://arcjet.com" target="_arcjet-home">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://arcjet.com/logo/arcjet-dark-lockup-voyage-horizontal.svg">
@@ -152,6 +153,19 @@ typically want to apply it to every route.
 Check out [the docs](https://docs.arcjet.com/), [contact
 support](https://docs.arcjet.com/support), or [join our Discord
 server](https://arcjet.com/discord).
+
+## Contributing
+
+All development for Arcjet examples is done in the
+[`arcjet/examples` repository](https://github.com/arcjet/examples).
+
+You are welcome to open an issue here or in
+[`arcjet/examples`](https://github.com/arcjet/examples/issues) directly.
+However, please direct all pull requests to
+[`arcjet/examples`](https://github.com/arcjet/examples/pulls). Take a look at
+our
+[contributing guide](https://github.com/arcjet/examples/blob/main/CONTRIBUTING.md)
+for more information.
 
 [vercel_deploy]: https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Farcjet%2Fexample-nestjs&project-name=arcjet-example&repository-name=arcjet-example&developer-id=oac_1GEcKBuKBilVnjToj1QUwdb8&demo-title=Arcjet%20Example%20&demo-description=Example%20rate%20limiting%2C%20bot%20protection%2C%20email%20verification%20%26%20form%20protection.&demo-url=https%3A%2F%2Fgithub.com%2Farcjet%2Fexample-nestjs&demo-image=https%3A%2F%2Fapp.arcjet.com%2Fimg%2Fexample-apps%2Fvercel%2Fdemo-image.jpg&integration-ids=oac_1GEcKBuKBilVnjToj1QUwdb8&external-id=example-nestjs
 [vercel_button]: https://vercel.com/button

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.1.2/schema.json",
+  "assist": {
+    "enabled": false
+  },
+  "files": {
+    "includes": ["src/**/*.ts"]
+  },
+  "formatter": {
+    "enabled": false
+  },
+  "javascript": {
+    "parser": {
+      "unsafeParameterDecoratorsEnabled": true
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "style": {
+        "useImportType": "off"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "example-nestjs",
+  "name": "@arcjet-examples/nestjs",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "example-nestjs",
+      "name": "@arcjet-examples/nestjs",
       "license": "Apache-2.0",
       "dependencies": {
         "@arcjet/decorate": "1.0.0-beta.9",
@@ -418,15 +418,15 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.9.tgz",
-      "integrity": "sha512-DBJBkzI5Wx4jFaYm221LHvAhpKYkhVS0k9plqHwaHhofGNxvYB7J3Bz8w+bFJ05zaMb0sZNHo4KdmENQFlNTuQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.2.0.tgz",
+      "integrity": "sha512-fdSw07FLJEU5vbpOPzXo5c6xmMGDzbZE2+niuDHX5N6mc6V0Ebso/q3xiHra4D73+PMsC8MJmcaZKuAAoaQsSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.14",
-        "@inquirer/figures": "^1.0.12",
-        "@inquirer/type": "^3.0.7",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -443,14 +443,14 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.1.13",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.13.tgz",
-      "integrity": "sha512-EkCtvp67ICIVVzjsquUiVSd+V5HRGOGQfsqA4E4vMWhYnB7InUL0pa0TIWt1i+OfP16Gkds8CdIu6yGZwOM1Yw==",
+      "version": "5.1.14",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.14.tgz",
+      "integrity": "sha512-5yR4IBfe0kXe59r1YCTG8WXkUbl7Z35HK87Sw+WUyGD8wNUx7JvY7laahzeytyE1oLn74bQnL7hstctQxisQ8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.14",
-        "@inquirer/type": "^3.0.7"
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -465,14 +465,14 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.1.14",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.14.tgz",
-      "integrity": "sha512-Ma+ZpOJPewtIYl6HZHZckeX1STvDnHTCB2GVINNUlSEn2Am6LddWwfPkIGY0IUFVjUUrr/93XlBwTK6mfLjf0A==",
+      "version": "10.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.15.tgz",
+      "integrity": "sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/figures": "^1.0.12",
-        "@inquirer/type": "^3.0.7",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
         "ansi-escapes": "^4.3.2",
         "cli-width": "^4.1.0",
         "mute-stream": "^2.0.0",
@@ -493,14 +493,14 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.14.tgz",
-      "integrity": "sha512-yd2qtLl4QIIax9DTMZ1ZN2pFrrj+yL3kgIWxm34SS6uwCr0sIhsNyudUjAo5q3TqI03xx4SEBkUJqZuAInp9uA==",
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.15.tgz",
+      "integrity": "sha512-wst31XT8DnGOSS4nNJDIklGKnf+8shuauVrWzgKegWUe28zfCftcWZ2vktGdzJgcylWSS2SrDnYUb6alZcwnCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.14",
-        "@inquirer/type": "^3.0.7",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8",
         "external-editor": "^3.1.0"
       },
       "engines": {
@@ -516,14 +516,14 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.16.tgz",
-      "integrity": "sha512-oiDqafWzMtofeJyyGkb1CTPaxUkjIcSxePHHQCfif8t3HV9pHcw1Kgdw3/uGpDvaFfeTluwQtWiqzPVjAqS3zA==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.17.tgz",
+      "integrity": "sha512-PSqy9VmJx/VbE3CT453yOfNa+PykpKg/0SYP7odez1/NWBGuDXgPhp4AeGYYKjhLn5lUUavVS/JbeYMPdH50Mw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.14",
-        "@inquirer/type": "^3.0.7",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -539,9 +539,9 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.12.tgz",
-      "integrity": "sha512-MJttijd8rMFcKJC8NYmprWr6hD3r9Gd9qUC0XwPNwoEPWSMVJwA2MlXxF+nhZZNMY+HXsWa+o7KY2emWYIn0jQ==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
+      "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -549,14 +549,14 @@
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.2.0.tgz",
-      "integrity": "sha512-opqpHPB1NjAmDISi3uvZOTrjEEU5CWVu/HBkDby8t93+6UxYX0Z7Ps0Ltjm5sZiEbWenjubwUkivAEYQmy9xHw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.2.1.tgz",
+      "integrity": "sha512-tVC+O1rBl0lJpoUZv4xY+WGWY8V5b0zxU1XDsMsIHYregdh7bN5X5QnIONNBAl0K765FYlAfNHS2Bhn7SSOVow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.14",
-        "@inquirer/type": "^3.0.7"
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -571,14 +571,14 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.16.tgz",
-      "integrity": "sha512-kMrXAaKGavBEoBYUCgualbwA9jWUx2TjMA46ek+pEKy38+LFpL9QHlTd8PO2kWPUgI/KB+qi02o4y2rwXbzr3Q==",
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.17.tgz",
+      "integrity": "sha512-GcvGHkyIgfZgVnnimURdOueMk0CztycfC8NZTiIY9arIAkeOgt6zG57G+7vC59Jns3UX27LMkPKnKWAOF5xEYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.14",
-        "@inquirer/type": "^3.0.7"
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -593,14 +593,14 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.16.tgz",
-      "integrity": "sha512-g8BVNBj5Zeb5/Y3cSN+hDUL7CsIFDIuVxb9EPty3lkxBaYpjL5BNRKSYOF9yOLe+JOcKFd+TSVeADQ4iSY7rbg==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.17.tgz",
+      "integrity": "sha512-DJolTnNeZ00E1+1TW+8614F7rOJJCM4y4BAGQ3Gq6kQIG+OJ4zr3GLjIjVVJCbKsk2jmkmv6v2kQuN/vriHdZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.14",
-        "@inquirer/type": "^3.0.7",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8",
         "ansi-escapes": "^4.3.2"
       },
       "engines": {
@@ -646,14 +646,14 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.4.tgz",
-      "integrity": "sha512-5GGvxVpXXMmfZNtvWw4IsHpR7RzqAR624xtkPd1NxxlV5M+pShMqzL4oRddRkg8rVEOK9fKdJp1jjVML2Lr7TQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.5.tgz",
+      "integrity": "sha512-R5qMyGJqtDdi4Ht521iAkNqyB6p2UPuZUbMifakg1sWtu24gc2Z8CJuw8rP081OckNDMgtDCuLe42Q2Kr3BolA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.14",
-        "@inquirer/type": "^3.0.7",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -669,15 +669,15 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.16.tgz",
-      "integrity": "sha512-POCmXo+j97kTGU6aeRjsPyuCpQQfKcMXdeTMw708ZMtWrj5aykZvlUxH4Qgz3+Y1L/cAVZsSpA+UgZCu2GMOMg==",
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.17.tgz",
+      "integrity": "sha512-CuBU4BAGFqRYors4TNCYzy9X3DpKtgIW4Boi0WNkm4Ei1hvY9acxKdBdyqzqBCEe4YxSdaQQsasJlFlUJNgojw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.14",
-        "@inquirer/figures": "^1.0.12",
-        "@inquirer/type": "^3.0.7",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -693,15 +693,15 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.2.4.tgz",
-      "integrity": "sha512-unTppUcTjmnbl/q+h8XeQDhAqIOmwWYWNyiiP2e3orXrg6tOaa5DHXja9PChCSbChOsktyKgOieRZFnajzxoBg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.3.1.tgz",
+      "integrity": "sha512-Gfl/5sqOF5vS/LIrSndFgOh7jgoe0UXEizDqahFRkq5aJBLegZ6WjuMh/hVEJwlFQjyLq1z9fRtvUMkb7jM1LA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.14",
-        "@inquirer/figures": "^1.0.12",
-        "@inquirer/type": "^3.0.7",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -718,9 +718,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.7.tgz",
-      "integrity": "sha512-PfunHQcjwnju84L+ycmcMKB/pTPIngjUJvfnRhKY6FKPuYXlM4aQCb/nIdTFR6BEhMjFvngzvng/vBAJMZpLSA==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
+      "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1257,8 +1257,6 @@
     },
     "node_modules/@types/node": {
       "version": "20.19.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.8.tgz",
-      "integrity": "sha512-HzbgCY53T6bfu4tT7Aq3TvViJyHjLjPNaAS3HOuMc9pw97KHsUtXNX4L+wu59g1WnjsZSko35MbEqnO58rihhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2287,9 +2285,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.183",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.183.tgz",
-      "integrity": "sha512-vCrDBYjQCAEefWGjlK3EpoSKfKbT10pR4XXPdn65q7snuNOZnthoVpBfZPykmDapOKfoD+MMIPG8ZjKyyc9oHA==",
+      "version": "1.5.189",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.189.tgz",
+      "integrity": "sha512-y9D1ntS1ruO/pZ/V2FtLE+JXLQe28XoRpZ7QCCo0T8LdQladzdcOVQZH/IWLVJvCw12OGMb6hYOeOAjntCmJRQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -2693,9 +2691,9 @@
       }
     },
     "node_modules/fs-monkey": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.6.tgz",
-      "integrity": "sha512-b1FMfwetIKymC0eioW7mTywihSQE4oLzQn1dB6rZB5fx/3NpNEdAWeCSMB+60/AeT0TCXsxzAlcYVEFCTAksWg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.1.0.tgz",
+      "integrity": "sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==",
       "dev": true,
       "license": "Unlicense"
     },
@@ -4322,9 +4320,9 @@
       }
     },
     "node_modules/strtok3": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.1.tgz",
-      "integrity": "sha512-3JWEZM6mfix/GCJBBUrkA8p2Id2pBkyTkVCJKto55w080QBKZ+8R171fGrbiSp+yMO/u6F8/yUh7K4V9K+YCnw==",
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.2.tgz",
+      "integrity": "sha512-or9w505RhhY66+uoe5YOC5QO/bRuATaoim3XTh+pGKx5VMWi/HDhMKuCjDLsLJouU2zg9Hf1nLPcNW7IHv80kQ==",
       "license": "MIT",
       "dependencies": {
         "@tokenizer/token": "^0.3.0"
@@ -4649,8 +4647,6 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -1,16 +1,12 @@
 {
-  "name": "example-nestjs",
+  "name": "@arcjet-examples/nestjs",
   "exports": "./index.js",
   "description": "Arcjet NestJS example app. Arcjet helps developers protect their apps in just a few lines of code. Bot detection. Rate limiting. Email validation. Attack protection. Data redaction. A developer-first approach to security.",
   "license": "Apache-2.0",
   "homepage": "https://arcjet.com",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/arcjet/example-nest.git",
-    "directory": "arcjet"
-  },
+  "repository": "github:arcjet/example-nestjs",
   "bugs": {
-    "url": "https://github.com/arcjet/example-nest/issues",
+    "url": "https://github.com/arcjet/examples/issues",
     "email": "support@arcjet.com"
   },
   "author": {
@@ -25,11 +21,8 @@
   },
   "scripts": {
     "build": "nest build",
-    "dev": "nest start",
-    "start": "nest start",
-    "start:dev": "nest start --watch",
-    "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main"
+    "dev": "nest start --watch",
+    "start": "nest start"
   },
   "dependencies": {
     "@arcjet/decorate": "1.0.0-beta.9",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,16 +1,16 @@
 import { ArcjetModule, shield } from '@arcjet/nest';
 import { Module } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AppController } from './app.controller.js';
 import { AppService } from './app.service.js';
 import { ArcjetLogger } from './arcjet-logger.js';
-import { BotsAdvancedModule } from './bots-advanced/bots-advanced.module.js';
-import { BotsModule } from './bots/bots.module.js';
-import { RateLimitingAdvancedModule } from './rate-limiting-advanced/rate-limiting-advanced.module.js';
-import { RateLimitingModule } from './rate-limiting/rate-limiting.module.js';
-import { SensitiveInfoAdvancedModule } from './sensitive-info-advanced/sensitive-info-advanced.module.js';
-import { SensitiveInfoModule } from './sensitive-info/sensitive-info.module.js';
 import { AttackModule } from './attack/attack.module.js';
+import { BotsModule } from './bots/bots.module.js';
+import { BotsAdvancedModule } from './bots-advanced/bots-advanced.module.js';
+import { RateLimitingModule } from './rate-limiting/rate-limiting.module.js';
+import { RateLimitingAdvancedModule } from './rate-limiting-advanced/rate-limiting-advanced.module.js';
+import { SensitiveInfoModule } from './sensitive-info/sensitive-info.module.js';
+import { SensitiveInfoAdvancedModule } from './sensitive-info-advanced/sensitive-info-advanced.module.js';
 import { SignupModule } from './signup/signup.module.js';
 
 @Module({
@@ -18,15 +18,27 @@ import { SignupModule } from './signup/signup.module.js';
     ConfigModule.forRoot({
       isGlobal: true,
       envFilePath: '.env.local',
+      validate(config) {
+        if (typeof config.ARCJET_KEY !== 'string') {
+          throw new Error(
+            'ARCJET_KEY must be set in the environment variables. Get your key at https://app.arcjet.com',
+          );
+        }
+        return config;
+      },
     }),
-    ArcjetModule.forRoot({
+    ArcjetModule.forRootAsync({
       isGlobal: true,
-      key: process.env.ARCJET_KEY!,
-      // Configures Arcjet Shield as a default rule everywhere. Shield protects
-      // against common attacks e.g. SQL injection, XSS, etc.
-      rules: [shield({ mode: 'LIVE' })],
-      // Configures Arcjet to use a Nest compatible logger
-      log: new ArcjetLogger(),
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: async (configService: ConfigService) => ({
+        key: configService.get('ARCJET_KEY'),
+        // Configures Arcjet Shield as a default rule everywhere. Shield protects
+        // against common attacks e.g. SQL injection, XSS, etc.
+        rules: [shield({ mode: 'LIVE' })],
+        // Configures Arcjet to use a Nest compatible logger
+        log: new ArcjetLogger(),
+      }),
     }),
     BotsModule,
     BotsAdvancedModule,

--- a/src/arcjet-logger.ts
+++ b/src/arcjet-logger.ts
@@ -1,31 +1,31 @@
-import { LoggerService, Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, LoggerService } from '@nestjs/common';
 
 // Sets up the built-in Arcjet logger to use the NestJS logger
 @Injectable()
 export class ArcjetLogger implements LoggerService {
   private readonly logger = new Logger(ArcjetLogger.name);
 
-  log(message: any, ...optionalParams: any[]) {
+  log(message, ...optionalParams) {
     this.logger.log(message, ...optionalParams);
   }
 
-  fatal(message: any, ...optionalParams: any[]) {
+  fatal(message, ...optionalParams) {
     this.logger.error(message, ...optionalParams);
   }
 
-  error(message: any, ...optionalParams: any[]) {
+  error(message, ...optionalParams) {
     this.logger.error(message, ...optionalParams);
   }
 
-  warn(message: any, ...optionalParams: any[]) {
+  warn(message, ...optionalParams) {
     this.logger.warn(message, ...optionalParams);
   }
 
-  debug(message: any, ...optionalParams: any[]) {
+  debug(message, ...optionalParams) {
     this.logger.debug(message, ...optionalParams);
   }
 
-  info(message: any, ...optionalParams: any[]) {
+  info(message, ...optionalParams) {
     this.logger.log(message, ...optionalParams);
   }
 }

--- a/src/attack/attack.controller.ts
+++ b/src/attack/attack.controller.ts
@@ -1,5 +1,5 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
 import { ArcjetGuard } from '@arcjet/nest';
+import { Controller, Get, UseGuards } from '@nestjs/common';
 import { AttackService } from './attack.service.js';
 
 @Controller('attack')

--- a/src/bots/bots.controller.ts
+++ b/src/bots/bots.controller.ts
@@ -1,5 +1,5 @@
+import { ArcjetGuard, detectBot, WithArcjetRules } from '@arcjet/nest';
 import { Controller, Get, UseGuards } from '@nestjs/common';
-import { ArcjetGuard, WithArcjetRules, detectBot } from '@arcjet/nest';
 import { BotsService } from './bots.service.js';
 
 @Controller('bots')

--- a/src/rate-limiting-advanced/rate-limiting-advanced.controller.ts
+++ b/src/rate-limiting-advanced/rate-limiting-advanced.controller.ts
@@ -47,7 +47,7 @@ export class RateLimitingAdvancedController {
     this.logger.log(`Arcjet: decision = ${decision.conclusion}`);
 
     // Use the IP analysis to customize the response based on the country
-    if (decision.ip.hasCountry() && decision.ip.country == 'JP') {
+    if (decision.ip.hasCountry() && decision.ip.country === 'JP') {
       return this.rateLimitingAdvancedController.messageJP();
     }
 


### PR DESCRIPTION
Via the work in https://github.com/arcjet/examples/pull/18

This is a consequence of the work to move development of this repository to the `examples` monorepo. This diff is _much_ easier to read.

Note that most of the changes are due to the standardized linting and formatting in the examples repo (notably the sorted imports for this diff).

In the future, the workflow will not include a pull request but will instead push to `main` directly.

Actions for merging:
- [ ] Remove push protection from `main` (sorry, I know we just added it)
- [ ] Merge this without squashing